### PR TITLE
Fixed broken link and example interactions

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -1,15 +1,15 @@
 # AWS EC2 cloud pool
-The [elastisys](http://elastisys.com/) AWS EC2 
+The [elastisys](http://elastisys.com/) AWS EC2
 [cloud pool](http://cloudpoolrestapi.readthedocs.org/en/latest/)
-manages a pool of EC2 instances. Pool members are identified by a 
-configurable tag and instances are continuously provisioned/decommissioned to 
-keep the pool's actual size in sync with the desired size that the cloud 
+manages a pool of EC2 instances. Pool members are identified by a
+configurable tag and instances are continuously provisioned/decommissioned to
+keep the pool's actual size in sync with the desired size that the cloud
 pool has been instructed to maintain.
 
 The cloud pool publishes a REST API that follows the general contract of an
 [elastisys](http://elastisys.com/) cloud pool, through which
 a client (for example, an autoscaler) can manage the pool.
-For the complete API reference, the reader is referred to the 
+For the complete API reference, the reader is referred to the
 [cloud pool API documentation](http://cloudpoolrestapi.readthedocs.org/en/latest/).
 
 *Note that if you plan on using a large number of on-demand instances for your service, you
@@ -20,14 +20,14 @@ To submit a limit increase request, go to [AWS Support Center](https://console.a
 
 ## Configuration
 The `ec2pool` is configured with a JSON document which follows the general
-structure described in the [root-level README.md](../README.md).
+structure described in the [root-level README.md](../../README.md).
 
-For the cloud-specific parts of the configuration (`cloudApiSettings` 
+For the cloud-specific parts of the configuration (`cloudApiSettings`
 and `provisioningTemplate`), the `ec2pool` requires input similar
 to the following:
 
 ```javascript
-    ...	
+    ...
     "cloudApiSettings": {
         "awsAccessKeyId": "ABC...123",
         "awsSecretAccessKey": "DEF...456",
@@ -35,7 +35,7 @@ to the following:
         "connectionTimeout": 10000,
         "socketTimeout": 10000
     },
-    
+
     "provisioningTemplate": {
         "size": "m1.small",
         "image": "ami-018c9568",
@@ -49,14 +49,14 @@ to the following:
 The configuration keys have the following meaning:
 
 - `cloudApiSettings`: API access credentials and settings.
-    - `awsAccessKeyId`: Your [AWS Access Key ID](https://aws-portal.amazon.com/gp/aws/securityCredentials). 
-    - `awsSecretAccessKey`: Your [AWS Secret Access Key](https://aws-portal.amazon.com/gp/aws/securityCredentials). 
+    - `awsAccessKeyId`: Your [AWS Access Key ID](https://aws-portal.amazon.com/gp/aws/securityCredentials).
+    - `awsSecretAccessKey`: Your [AWS Secret Access Key](https://aws-portal.amazon.com/gp/aws/securityCredentials).
     - `region`: The [AWS region](http://docs.aws.amazon.com/general/latest/gr/rande.html) to connect to.
     - `connectionTimeout`: The timeout in milliseconds until a connection is established.
     - `socketTimeout`: The socket timeout (`SO_TIMEOUT`) in milliseconds, which is the
-	  timeout for waiting for data or, put differently, a maximum period inactivity 
+	  timeout for waiting for data or, put differently, a maximum period inactivity
 	  between two consecutive data packets.
-		
+
 - `provisioningTemplate`: Describes how to provision additional servers (on scale-up).
     - `size`: The [instance type](http://aws.amazon.com/ec2/instance-types/instance-details/) to use for new machine instances.
     - `image`: The [AMI](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) id to use for new machine instances.
@@ -77,7 +77,7 @@ The simplest way of starting the server is to run
 
     java -jar <jar-file> --http-port=8080
 
-which will start a server listening on HTTP port `8080`. 
+which will start a server listening on HTTP port `8080`.
 
 *Note: for production settings, it is recommended to run the server with an HTTPS port.*
 
@@ -90,16 +90,16 @@ run the server with the `--help` flag:
 
 
 ## Running the cloud pool in a Docker container
-The cloud pool can be executed inside a 
-[Docker](https://www.docker.com/) container. First, however, a docker image 
-needs to be built that includes the cloud pool. The steps for building 
+The cloud pool can be executed inside a
+[Docker](https://www.docker.com/) container. First, however, a docker image
+needs to be built that includes the cloud pool. The steps for building
 the image and running a container from the image are outlined below.
 
 Before proceeding, make sure that your user is a member of the `docker` user group.
 Without being a member of that user group, you won't be able to use docker without
- sudo/root privileges. 
+ sudo/root privileges.
 
-See the [docker documentation](https://docs.docker.com/installation/ubuntulinux/#giving-non-root-access) 
+See the [docker documentation](https://docs.docker.com/installation/ubuntulinux/#giving-non-root-access)
 for more details.
 
 
@@ -116,7 +116,7 @@ pushed to our private docker registry.
 
 
 ### Running a container from the image
-Once the docker image is built for the server, it can be run by either 
+Once the docker image is built for the server, it can be run by either
 specfying a HTTP port or an HTTPS port. For example, running with an HTTP port:
 
     docker run -d -p 8080:80 -e HTTP_PORT=80 <image>
@@ -126,12 +126,12 @@ This will start publish the container's HTTP port on host port `8080`.
 *Note: for production settings, it is recommended to run the server with an HTTPS port.*
 
 The following environment variables can be passed to the Docker container (`-e`)
-to control its behavior. At least one of `${HTTP_PORT}` and `${HTTPS_PORT}` 
+to control its behavior. At least one of `${HTTP_PORT}` and `${HTTPS_PORT}`
 _must_ be specified.
 
 Singleton/multipool mode:
 
-  - `MULTIPOOL`: Set to `true` to start the server in [multipool](../../multipool/README.md)-mode, 
+  - `MULTIPOOL`: Set to `true` to start the server in [multipool](../../multipool/README.md)-mode,
     in which it will publish a dynamic collection of *cloudpool instances*.
     The default is to run the server as a singleton cloudpool.
 
@@ -142,17 +142,17 @@ HTTP/HTTPS configuration:
 
   - `HTTPS_PORT`: Enables a HTTPS port on the server.  
     *Note: when specified, a `${SSL_KEYSTORE}` must be specified to identify to clients.*
-	
+
   - `SSL_KEYSTORE`: The location of the server's SSL key store (PKCS12 format).  
      You typically combine this with mounting a volume that holds the key store.  
 	 *Note: when specified, an `${SSL_KEYSTORE_PASSWORD}` must is required.*
-	 
+
   - `SSL_KEYSTORE_PASSWORD`: The password that protects the key store.  
 
 Runtime configuration:
 
   - `STORAGE_DIR`: destination folder for runtime state.  
-    *Note: to persist across container recreation, this directory should be 
+    *Note: to persist across container recreation, this directory should be
 	mapped via a volume to a directory on the host.*  
     Default: `/var/lib/elastisys/ec2pool`.
 
@@ -167,7 +167,7 @@ Debug-related:
   - `LOG_DIR`: destination folder for log files (when using default
     `${LOG_CONFIG}` setup).  
     Default: `/var/log/elastisys/ec2pool`.
-  - `STDOUT_LOG_LEVEL`: output level for logging to stdout (note: log output 
+  - `STDOUT_LOG_LEVEL`: output level for logging to stdout (note: log output
     that is written to file includes `DEBUG` level).  
     Default: `INFO`.
 
@@ -195,7 +195,7 @@ JVM-related:
 
 ### Debugging a running container
 The simplest way to debug a running container is to get a shell session via
-  
+
     docker exec -it <container-id/name> /bin/bash
 
 and check out the log files under `/var/log/elastisys`. Configurations are
@@ -204,14 +204,14 @@ located under `/etc/elastisys` and binaries under `/opt/elastisys`.
 
 
 ## Interacting with the cloud pool over its REST API
-The following examples, all using the [curl](http://en.wikipedia.org/wiki/CURL) 
+The following examples, all using the [curl](http://en.wikipedia.org/wiki/CURL)
 command-line tool, shows how to interact with the cloud pool over its
 [REST API](http://cloudpoolrestapi.readthedocs.org/en/latest/).
 
 The exact command-line arguments to pass to curl depends on the security
 settings that the server was launched with. For example, if client-certificate
-authentication is enforced (`--require-cert`), one needs to pass client 
-certificate credentials via `curl`: 
+authentication is enforced (`--require-cert`), one needs to pass client
+certificate credentials via `curl`:
 
     --key-type pem --key key.pem --cert-type pem --cert cert.pem
 
@@ -222,7 +222,7 @@ Here are some examples illustrating basic interactions with the cloud pool
 1. Retrieve the currently set configuration document:
 
         curl -X GET http://localhost:8080/config
-    
+
 
 2. Set configuration:
 
@@ -237,9 +237,9 @@ Here are some examples illustrating basic interactions with the cloud pool
 
 4. Retrieve the current machine pool:
 
-        curl -X POST http://localhost:8080/pool
+        curl -X GET http://localhost:8080/pool
 
 5. Request the machine pool to be resized to size ``4``:
 
         curl --header "Content-Type:application/json" \
-                    -X POST -d '{"desiredCapacity": 4}' http://localhost:8080/config
+                    -X POST -d '{"desiredSize": 4}' http://localhost:8080/pool/size


### PR DESCRIPTION
    - Fixed link to the root README
    - Example for getting pool used POST instead of GET
    - Fixed path and parameter for setting pool size example
    - Some white space removed