### PR TITLE
azure: Use Region enum instead of region name string

### DIFF
--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/AzurePoolDriver.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/AzurePoolDriver.java
@@ -32,6 +32,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 /**
  * The {@link AzurePoolDriver} is a management interface towards the Azure API.
@@ -249,8 +250,8 @@ public class AzurePoolDriver implements CloudPoolDriver {
      * @throws NotFoundException
      */
     private void ensureRightRegionAndResouceGroup(VirtualMachine vm) throws NotFoundException {
-        String cloudpoolRegion = cloudApiSettings().getRegion();
-        if (!vm.regionName().equalsIgnoreCase(cloudpoolRegion)) {
+        Region cloudpoolRegion = cloudApiSettings().getRegion();
+        if (!vm.region().equals(cloudpoolRegion)) {
             throw new NotFoundException(String.format("the specified vm is located region %s, cloudpool uses region %s",
                     vm.regionName(), cloudpoolRegion));
         }

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/StandardAzureClient.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/StandardAzureClient.java
@@ -75,7 +75,7 @@ public class StandardAzureClient implements AzureClient {
 
         // filter out VMs in wrong region and with wrong tag set
         List<VirtualMachine> filteredVms = vms.stream()//
-                .filter(vm -> vm.regionName().equals(this.config.getRegion())) //
+                .filter(vm -> vm.region().equals(this.config.getRegion())) //
                 .filter(vm -> vm.tags().entrySet().containsAll(withTags.entrySet()))//
                 .collect(Collectors.toList());
         return filteredVms;

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/VmLauncher.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/VmLauncher.java
@@ -30,6 +30,7 @@ import com.microsoft.azure.management.compute.VirtualMachine.DefinitionStages.Wi
 import com.microsoft.azure.management.compute.VirtualMachine.DefinitionStages.WithFromImageCreateOptionsUnmanaged;
 import com.microsoft.azure.management.compute.VirtualMachine.DefinitionStages.WithOS;
 import com.microsoft.azure.management.network.NetworkInterface;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.management.resources.fluentcore.model.Creatable;
 import com.microsoft.azure.management.resources.fluentcore.model.CreatedResources;
 import com.microsoft.azure.management.storage.StorageAccount;
@@ -50,11 +51,11 @@ public class VmLauncher {
 
     private final AzureApiAccess apiAccess;
     private final String resourceGroup;
-    private final String region;
+    private final Region region;
 
     // private final Azure api;
 
-    public VmLauncher(AzureApiAccess apiAccess, String resourceGroup, String region) {
+    public VmLauncher(AzureApiAccess apiAccess, String resourceGroup, Region region) {
         this.apiAccess = apiAccess;
         this.resourceGroup = resourceGroup;
         this.region = region;

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/VmSpecValidator.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/client/impl/VmSpecValidator.java
@@ -18,6 +18,7 @@ import com.elastisys.scale.cloudpool.azure.driver.requests.GetVmSizesRequest;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.network.NetworkSecurityGroup;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 /**
  * Validates {@link VmSpec}s prior to launch to make sure referenced Azure
@@ -33,7 +34,7 @@ public class VmSpecValidator {
      * Azure region where referenced assets are assume to be located. For
      * example, "northeurope".
      */
-    private final String region;
+    private final Region region;
     /** Azure resource group where referenced assets are assumed to exist. */
     private final String resourceGroup;
 
@@ -49,7 +50,7 @@ public class VmSpecValidator {
      *            Azure resource group where referenced assets are assumed to
      *            exist.
      */
-    public VmSpecValidator(AzureApiAccess apiAccess, String region, String resourceGroup) {
+    public VmSpecValidator(AzureApiAccess apiAccess, Region region, String resourceGroup) {
         this.apiAccess = apiAccess;
         this.region = region;
         this.resourceGroup = resourceGroup;

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/config/CloudApiSettings.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/config/CloudApiSettings.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import com.elastisys.scale.cloudpool.azure.driver.AzurePoolDriver;
 import com.elastisys.scale.cloudpool.commons.basepool.config.BaseCloudPoolConfig;
 import com.elastisys.scale.commons.json.JsonUtils;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
@@ -88,8 +89,8 @@ public class CloudApiSettings {
      *
      * @return
      */
-    public String getRegion() {
-        return this.region;
+    public Region getRegion() {
+        return Region.findByLabelOrName(this.region);
     }
 
     @Override
@@ -112,6 +113,8 @@ public class CloudApiSettings {
         checkArgument(this.apiAccess != null, "driverConfig: no apiAccess given");
         checkArgument(this.resourceGroup != null, "driverConfig: no resourceGroup given");
         checkArgument(this.region != null, "driverConfig: no region given");
+
+        checkArgument(this.getRegion() != null, "driverConfig: region '%s' not recognized", this.region);
 
         try {
             this.apiAccess.validate();

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/requests/CreateNetworkInterfaceRequest.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/requests/CreateNetworkInterfaceRequest.java
@@ -7,6 +7,7 @@ import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.network.NetworkInterface.DefinitionStages.WithCreate;
 import com.microsoft.azure.management.network.NetworkSecurityGroup;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 /**
  * An Azure request that, when called, creates a {@link NetworkInterface} in a
@@ -20,7 +21,7 @@ public class CreateNetworkInterfaceRequest extends AzureRequest<NetworkInterface
     /** The resource group under which to create the network interface. */
     private final String resourceGroup;
     /** The region in which to create the network interface. */
-    private final String region;
+    private final Region region;
     /** The name of the network interface to create. */
     private final String nicName;
 
@@ -46,7 +47,7 @@ public class CreateNetworkInterfaceRequest extends AzureRequest<NetworkInterface
      *            network and subnet it belongs to, if it should have an
      *            associated public IP and network security groups.
      */
-    public CreateNetworkInterfaceRequest(AzureApiAccess apiAccess, String resourceGroup, String region, String nicName,
+    public CreateNetworkInterfaceRequest(AzureApiAccess apiAccess, String resourceGroup, Region region, String nicName,
             NetworkSettings networkSettings) {
         super(apiAccess);
 

--- a/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/requests/GetVmSizesRequest.java
+++ b/azure/src/main/java/com/elastisys/scale/cloudpool/azure/driver/requests/GetVmSizesRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.elastisys.scale.cloudpool.azure.driver.config.AzureApiAccess;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 /**
  * An Azure request that, when called, fetches available VM sizes in a given
@@ -15,7 +16,7 @@ import com.microsoft.azure.management.compute.VirtualMachineSize;
 public class GetVmSizesRequest extends AzureRequest<List<VirtualMachineSize>> {
 
     /** The Azure region of interest. */
-    private final String regionName;
+    private final Region region;
 
     /**
      * Creates a {@link GetVmSizesRequest} for a particular region.
@@ -25,14 +26,14 @@ public class GetVmSizesRequest extends AzureRequest<List<VirtualMachineSize>> {
      * @param regionName
      *            The Azure region of interest.
      */
-    public GetVmSizesRequest(AzureApiAccess apiAccess, String regionName) {
+    public GetVmSizesRequest(AzureApiAccess apiAccess, Region region) {
         super(apiAccess);
-        this.regionName = regionName;
+        this.region = region;
     }
 
     @Override
     public List<VirtualMachineSize> doRequest(Azure api) throws RuntimeException {
-        return new ArrayList<>(api.virtualMachines().sizes().listByRegion(this.regionName));
+        return new ArrayList<>(api.virtualMachines().sizes().listByRegion(this.region));
     }
 
 }

--- a/azure/src/test/java/com/elastisys/scale/cloudpool/azure/driver/config/TestAzurePoolDriverConfig.java
+++ b/azure/src/test/java/com/elastisys/scale/cloudpool/azure/driver/config/TestAzurePoolDriverConfig.java
@@ -18,6 +18,8 @@ public class TestAzurePoolDriverConfig {
     private static final String resourceGroup = "testpool";
     /** Sample Azure region. */
     private static final String region = "northeurope";
+    /** Sample Azure region label. */
+    private static final String regionLabel = "North Europe";
 
     /**
      * Appropriate configuration values should pass validation and set values
@@ -30,7 +32,7 @@ public class TestAzurePoolDriverConfig {
 
         assertThat(driverConfig.getApiAccess(), is(validApiAccess()));
         assertThat(driverConfig.getResourceGroup(), is(resourceGroup));
-        assertThat(driverConfig.getRegion(), is(region));
+        assertThat(driverConfig.getRegion().name(), is(region));
     }
 
     /**
@@ -86,6 +88,32 @@ public class TestAzurePoolDriverConfig {
             fail("should fail");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("apiAccess"));
+        }
+    }
+
+    /**
+     * Both region names and labels are allowed.
+     */
+    @Test
+    public void onRegionLabel() {
+        CloudApiSettings driverConfig = new CloudApiSettings(validApiAccess(), resourceGroup, regionLabel);
+        driverConfig.validate();
+
+        assertThat(driverConfig.getApiAccess(), is(validApiAccess()));
+        assertThat(driverConfig.getResourceGroup(), is(resourceGroup));
+        assertThat(driverConfig.getRegion().name(), is(region));
+    }
+
+    /**
+     * Unrecognized region should fail.
+     */
+    @Test
+    public void onRegionUnrecognized() {
+        try {
+            new CloudApiSettings(validApiAccess(), resourceGroup, "notaregion").validate();
+            fail("should fail");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("not recognized"));
         }
     }
 

--- a/azure/src/test/java/com/elastisys/scale/cloudpool/azure/lab/CreateLinuxVirtualMachine.java
+++ b/azure/src/test/java/com/elastisys/scale/cloudpool/azure/lab/CreateLinuxVirtualMachine.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.rest.LogLevel;
 
 /**
@@ -33,7 +34,7 @@ public class CreateLinuxVirtualMachine extends BaseLabProgram {
 
     public static void main(String[] args) throws CloudException, IOException {
         String resourceGroup = "itest";
-        String region = "northeurope";
+        Region region = Region.findByLabelOrName("northeurope");
         String storageAccountName = "itestdisks";
 
         AzureApiAccess apiAccess = new AzureApiAccess(SUBSCRIPTION_ID, AZURE_AUTH,


### PR DESCRIPTION
Allows for region name as well as region labels, i.e. both
'northeurope' and 'North Europe'.